### PR TITLE
Fix test file managers not respecting custom suffixes

### DIFF
--- a/plugin/tongs-runner/src/main/java/com/github/tarcv/tongs/device/DeviceTestFilesCleanerImpl.java
+++ b/plugin/tongs-runner/src/main/java/com/github/tarcv/tongs/device/DeviceTestFilesCleanerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 TarCV
+ * Copyright 2021 TarCV
  * Copyright 2018 Shazam Entertainment Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class DeviceTestFilesCleanerImpl implements DeviceTestFilesCleaner {
 
     @Override
     public boolean deleteTraceFiles(TestCaseEvent testIdentifier) {
-        File file = fileManager.getFile(TEST, pool, device, testIdentifier.getTestCase());
+        File file = fileManager.getFile(TEST, pool, device, testIdentifier.getTestCase(), "");
         boolean isDeleted = file.delete();
         if (!isDeleted) {
             logger.warn("Failed to delete a file {}", file.getAbsolutePath());

--- a/plugin/tongs-runner/src/main/java/com/github/tarcv/tongs/system/io/FileManager.java
+++ b/plugin/tongs-runner/src/main/java/com/github/tarcv/tongs/system/io/FileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 TarCV
+ * Copyright 2021 TarCV
  * Copyright 2015 Shazam Entertainment Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
@@ -35,7 +35,7 @@ public interface FileManager {
 
     File getFile(FileType fileType, String pool, String device, TestCase testIdentifier);
 
-    File getFile(FileType fileType, Pool pool, Device device, TestCase testIdentifier);
+    File getFile(FileType fileType, Pool pool, Device device, TestCase testIdentifier, String suffix);
 
-    File getRelativeFile(FileType fileType, Pool pool, Device device, TestCase testIdentifier);
+    File getRelativeFile(FileType fileType, Pool pool, Device device, TestCase testIdentifier, String suffix);
 }

--- a/plugin/tongs-runner/src/main/java/com/github/tarcv/tongs/system/io/TestCaseFileManagerImpl.kt
+++ b/plugin/tongs-runner/src/main/java/com/github/tarcv/tongs/system/io/TestCaseFileManagerImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 TarCV
+ * Copyright 2021 TarCV
  * Copyright 2018 Shazam Entertainment Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
@@ -27,11 +27,11 @@ class TestCaseFileManagerImpl(
         private val testCaseEvent: TestCase
 ) : TestCaseFileManager {
     override fun getFile(fileType: FileType, suffix: String): File {
-        return fileManager.getFile(fileType, pool, device, testCaseEvent);
+        return fileManager.getFile(fileType, pool, device, testCaseEvent, suffix);
     }
 
     override fun getRelativeFile(fileType: FileType, suffix: String): File {
-        return fileManager.getRelativeFile(fileType, pool, device, testCaseEvent);
+        return fileManager.getRelativeFile(fileType, pool, device, testCaseEvent, suffix);
     }
 
     override fun createFile(fileType: FileType): File {

--- a/plugin/tongs-runner/src/main/java/com/github/tarcv/tongs/system/io/TongsFileManager.java
+++ b/plugin/tongs-runner/src/main/java/com/github/tarcv/tongs/system/io/TongsFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 TarCV
+ * Copyright 2021 TarCV
  * Copyright 2018 Shazam Entertainment Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
@@ -99,15 +99,15 @@ public class TongsFileManager implements FileManager {
     }
 
     @Override
-    public File getFile(FileType fileType, Pool pool, Device device, TestCase testIdentifier) {
-        String filenameForTest = FileUtils.createFilenameForTest(testIdentifier, fileType);
+    public File getFile(FileType fileType, Pool pool, Device device, TestCase testIdentifier, String suffix) {
+        String filenameForTest = FileUtils.createFilenameForTest(testIdentifier, fileType, suffix);
         Path path = get(output.getAbsolutePath(), fileType.getDirectory(), pool.getName(), device.getSafeSerial(), filenameForTest);
         return path.toFile();
     }
 
     @Override
-    public File getRelativeFile(FileType fileType, Pool pool, Device device, TestCase testIdentifier) {
-        File absoluteFile = getFile(fileType, pool, device, testIdentifier);
+    public File getRelativeFile(FileType fileType, Pool pool, Device device, TestCase testIdentifier, String suffix) {
+        File absoluteFile = getFile(fileType, pool, device, testIdentifier, suffix);
         return output.getAbsoluteFile().toPath().relativize(absoluteFile.toPath()).toFile();
     }
 

--- a/plugin/tongs-runner/src/test/java/com/github/tarcv/tongs/KoinUtil.kt
+++ b/plugin/tongs-runner/src/test/java/com/github/tarcv/tongs/KoinUtil.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 TarCV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.github.tarcv.tongs
+
+import org.koin.core.context.KoinContextHandler
+import org.koin.core.context.stopKoin
+
+fun stopKoinIfNeeded() {
+    if (KoinContextHandler.getOrNull() != null) {
+        stopKoin()
+    }
+}

--- a/plugin/tongs-runner/src/test/java/com/github/tarcv/tongs/summary/SummarizerIntegrationTest.kt
+++ b/plugin/tongs-runner/src/test/java/com/github/tarcv/tongs/summary/SummarizerIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 TarCV
+ * Copyright 2021 TarCV
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  *
@@ -19,6 +19,7 @@ import com.github.tarcv.tongs.injector.summary.OutcomeAggregatorInjector.outcome
 import com.github.tarcv.tongs.injector.summary.SummaryCompilerInjector.summaryCompiler
 import com.github.tarcv.tongs.injector.summary.SummaryPrinterInjector.summaryPrinter
 import com.github.tarcv.tongs.model.AndroidDevice
+import com.github.tarcv.tongs.stopKoinIfNeeded
 import com.github.tarcv.tongs.suite.ApkTestCase
 import com.github.tarcv.tongs.system.io.FileManager
 import com.github.tarcv.tongs.system.io.TestCaseFileManagerImpl
@@ -138,6 +139,8 @@ class SummarizerIntegrationTest {
         val runnerModule = module {
             single { configuration }
         }
+
+        stopKoinIfNeeded()
         startKoin {
             modules(runnerModule)
         }

--- a/plugin/tongs-runner/src/test/java/com/github/tarcv/tongs/summary/TemplateTest.kt
+++ b/plugin/tongs-runner/src/test/java/com/github/tarcv/tongs/summary/TemplateTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 TarCV
+ * Copyright 2021 TarCV
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License.
@@ -12,15 +12,13 @@
  */
 package com.github.tarcv.tongs.summary
 
-import com.github.tarcv.tongs.injector.summary.HtmlGeneratorInjector.htmlGenerator
 import com.github.tarcv.tongs.api.devices.Device.TEST_DEVICE
 import com.github.tarcv.tongs.api.devices.Pool.Builder.aDevicePool
 import com.github.tarcv.tongs.api.result.*
-import com.github.tarcv.tongs.api.run.*
-import com.github.tarcv.tongs.api.testcases.TestCase
 import com.github.tarcv.tongs.api.result.StandardFileTypes.*
-import com.github.tarcv.tongs.api.run.TestCaseEvent.Companion.TEST_TYPE_TAG
+import com.github.tarcv.tongs.api.run.ResultStatus
 import com.github.tarcv.tongs.api.testcases.aTestCase
+import com.github.tarcv.tongs.injector.summary.HtmlGeneratorInjector.htmlGenerator
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test

--- a/plugin/tongs-runner/src/test/java/com/github/tarcv/tongs/system/io/TestCaseFileManagerImplTest.kt
+++ b/plugin/tongs-runner/src/test/java/com/github/tarcv/tongs/system/io/TestCaseFileManagerImplTest.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2021 TarCV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.github.tarcv.tongs.system.io
+
+import com.github.tarcv.tongs.aConfigurationBuilder
+import com.github.tarcv.tongs.api.devices.Device
+import com.github.tarcv.tongs.api.devices.Pool
+import com.github.tarcv.tongs.api.result.FileType
+import com.github.tarcv.tongs.api.result.TestCaseFileManager
+import com.github.tarcv.tongs.api.testcases.aTestCase
+import com.github.tarcv.tongs.injector.system.FileManagerInjector
+import com.github.tarcv.tongs.stopKoinIfNeeded
+import org.apache.commons.lang3.RandomStringUtils
+import org.junit.Assert
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+import java.io.File
+import kotlin.random.Random
+
+class TestCaseFileManagerImplTest(
+) {
+    private val poolName = RandomStringUtils.randomAlphanumeric(10)
+    private val deviceName: String
+    private val testCase = aTestCase(
+        RandomStringUtils.randomAlphanumeric(10),
+        RandomStringUtils.randomAlphanumeric(10)
+    )
+    private val testCaseFixedClass = testCase.testClass.replace(".", "_")
+
+    private val tempFileRule = TemporaryFolder()
+
+    private val fileManager: TestCaseFileManager
+
+    init {
+        tempFileRule.create()
+
+        val configuration = aConfigurationBuilder()
+            .withOutput(tempFileRule.newFolder("output"))
+            .build(true)
+
+        val runnerModule = module {
+            single { configuration }
+        }
+
+        stopKoinIfNeeded()
+        startKoin {
+            modules(runnerModule)
+        }
+
+        val testDevice = Device.TEST_DEVICE
+        deviceName = testDevice.safeSerial
+
+        fileManager = run {
+            val device = testDevice
+            val pool = Pool.Builder()
+                .withName(poolName)
+                .addDevice(device)
+                .build()
+            TestCaseFileManagerImpl(FileManagerInjector.fileManager(), pool, device, testCase)
+        }
+    }
+
+    private val typeDirectory = "dirIHJ"
+    private val typeSuffix = "suffixKLM"
+    private val fileType = object : FileType {
+        override fun getDirectory(): String = typeDirectory
+
+        override fun getSuffix(): String = typeSuffix
+
+    }
+
+    @Test
+    fun testCaseFile() {
+        val suffix = RandomStringUtils.randomAlphanumeric(10)
+
+        val testCaseFile = fileManager.testCaseFile(fileType, suffix)
+
+        val file = testCaseFile.toFile()
+        assertFileNotCreated(file)
+        assertParentCreated(file, false)
+        assertFullFileQualification(file, suffix)
+    }
+
+    @Test
+    fun testGetFileFromFileType() {
+        val suffix = RandomStringUtils.randomAlphanumeric(10)
+
+        val file = fileManager.getFile(fileType, suffix)
+
+        assertFileNotCreated(file)
+        assertParentCreated(file, false)
+        assertFullFileQualification(file, suffix)
+    }
+
+    @Test
+    fun getRelativeFile() {
+        val suffix = RandomStringUtils.randomAlphanumeric(10)
+
+        val file = fileManager.getRelativeFile(fileType, suffix)
+
+        assertFileNotCreated(file)
+        assertParentCreated(file, false)
+        assertFullFileQualification(file, suffix)
+    }
+
+    @Test
+    fun testCreateFileBasic() {
+        val file = fileManager.createFile(fileType)
+
+        assertFileNotCreated(file)
+        assertParentCreated(file, true)
+        assertFullFileQualification(file)
+    }
+
+    @Test
+    fun testCreateFileWithSuffix() {
+        val suffix = RandomStringUtils.randomAlphanumeric(10)
+
+        val file = fileManager.createFile(fileType, suffix)
+
+        assertFileNotCreated(file)
+        assertParentCreated(file, true)
+        assertFullFileQualification(file, suffix)
+    }
+
+    @Test
+    fun testCreateFileWithSequenceNumber() {
+        val sequenceNum: Int = Random.Default.nextInt()
+
+        val file = fileManager.createFile(fileType, sequenceNum)
+
+        assertFileNotCreated(file)
+        assertParentCreated(file, true)
+        assertFullFileQualification(file, sequenceNum.toString())
+    }
+
+    private fun assertParentCreated(file: File, state: Boolean) {
+        val notStr = if (state) { "" } else { "not " }
+        Assert.assertTrue(
+            "The file parent directory should ${notStr}be created",
+            file.parentFile.exists() == state
+        )
+    }
+
+    private fun assertFileNotCreated(file: File) {
+        Assert.assertTrue(
+            "The file should not be created",
+            !file.exists()
+        )
+    }
+
+    private fun assertFullFileQualification(file: File, suffix: String = "") {
+        if (suffix.isNotEmpty()) {
+            Assert.assertTrue(
+                "'${file.path}' should contain with the passed suffix '$suffix'",
+                file.path.contains(suffix)
+            )
+        }
+        Assert.assertTrue(
+            "'${file.path}' should end with the file type suffix '${fileType.suffix}'",
+            file.path.endsWith(".${fileType.suffix}")
+        )
+        Assert.assertTrue(
+            "'${file.path}' should contain the current pool name '$poolName'",
+            file.path.contains(poolName)
+        )
+        Assert.assertTrue(
+            "'${file.path}' should contain the current device name '$deviceName'",
+            file.path.contains(deviceName)
+        )
+        Assert.assertTrue(
+            "'${file.path}' should contain the current test class name '$testCaseFixedClass'",
+            file.path.contains(testCaseFixedClass)
+        )
+        Assert.assertTrue(
+            "'${file.path}' should contain the current test method name '${testCase.testMethod}'",
+            file.path.contains(testCase.testMethod)
+        )
+    }
+}


### PR DESCRIPTION
* Fix test file managers not respecting custom suffixes
* Add a helper to restart Koin from scratch