### PR TITLE
Improve handling of annotation collection errors

### DIFF
--- a/plugin/tongs-plugin-android/src/main/java/com/github/tarcv/tongs/suite/JUnitTestCaseProvider.kt
+++ b/plugin/tongs-plugin-android/src/main/java/com/github/tarcv/tongs/suite/JUnitTestCaseProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 TarCV
+ * Copyright 2022 TarCV
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  *
@@ -229,7 +229,12 @@ class JUnitTestCaseProvider(
 
         val allTests = devicesInfo.keys
 
-        val testsWithoutInfo = allTests - annotationInfos.keys
+        val testsWithoutInfo = (allTests - annotationInfos.keys)
+            .filterNot {
+                // this is a synthetic test name meaning something crashed while collecting the list of tests
+                it.testName == "initializationError"
+            }
+
         if (testsWithoutInfo.isNotEmpty()) {
             throw RuntimeException(
                     "In pool ${context.pool.name} received no additional information" +

--- a/plugin/tongs-plugin-android/src/main/java/com/github/tarcv/tongs/suite/JUnitTestCaseProvider.kt
+++ b/plugin/tongs-plugin-android/src/main/java/com/github/tarcv/tongs/suite/JUnitTestCaseProvider.kt
@@ -236,9 +236,10 @@ class JUnitTestCaseProvider(
             }
 
         if (testsWithoutInfo.isNotEmpty()) {
-            throw RuntimeException(
-                    "In pool ${context.pool.name} received no additional information" +
-                            " for ${testsWithoutInfo.joinToString(", ")}")
+            logger.warn(
+                    "In pool ${context.pool.name} received no annotation information" +
+                            " for ${testsWithoutInfo.joinToString(", ")}"
+            )
         }
 
         return annotationInfos


### PR DESCRIPTION
- Ignore pseudo-test `initializationError` created by JUnit
- Collection errors should not be fatal